### PR TITLE
Add support for compressed TSW3 liveries

### DIFF
--- a/CompressionHelper.cs
+++ b/CompressionHelper.cs
@@ -87,11 +87,10 @@ namespace TSW3LM
             var bytes = ms.ToArray().ToList();
 
             // Re-add the bytes necessary for a TSW3 livery
-            bytes.Insert(0, 136);
-            bytes.Insert(1, 123);
-            bytes.Insert(2, 1);
+            bytes.Insert(0, 85);
+            bytes.Insert(1, 7);
+            bytes.Insert(2, 0);
             bytes.Insert(3, 0);
-            bytes.RemoveAt(bytes.Count - 1);
 
             // Deflate
             using var outputByteStream = new MemoryStream();
@@ -105,8 +104,8 @@ namespace TSW3LM
 
             // Now reassemble the whole thing
             var header = new byte[] { 193, 131, 42, 158, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0 };
-            var compressedMemoryStream = new MemoryStream();
-            var compressedWriter = new BinaryWriter(compressedMemoryStream);
+            using var compressedMemoryStream = new MemoryStream();
+            using var compressedWriter = new BinaryWriter(compressedMemoryStream);
 
             compressedWriter.Write(header, 0, header.Length);
 
@@ -152,20 +151,17 @@ namespace TSW3LM
                 {
                     idProperty,
                     arrayProperty,
-                    new UENoneProperty
-                    {
-                        Name = "None"
-                    }
+                    new UENoneProperty()
                 }
             };
-
-            // TODO this calculation is not correct and causes TSW3LM to fail after importing
+            
             compressedProperty.ValueLength = Utils.DetermineValueLength(compressedProperty, r =>
             {
                 r.ReadUEString(); //name
                 r.ReadUEString(); //type
                 r.ReadInt64(); //valueLength
-                r.ReadUEString(); //itemType
+                r.ReadUEString();
+                r.ReadBytes(16);
                 r.ReadByte(); //terminator
                 return r.BaseStream.Length - r.BaseStream.Position;
             });

--- a/CompressionHelper.cs
+++ b/CompressionHelper.cs
@@ -21,7 +21,7 @@ namespace TSW3LM
             if (byteString == null)
                 return null;
 
-            var byteArray = Utils.StringToByteArray(byteString.Value);
+            var byteArray = Utils.HexStringToByteArray(byteString.Value);
             using var memoryStream = new MemoryStream(byteArray);
             using var binaryReader = new BinaryReader(memoryStream);
 
@@ -121,7 +121,7 @@ namespace TSW3LM
             // Serialize the thing back to a string
             compressedMemoryStream.Position = 0;
             var compressedBytes = compressedMemoryStream.ToArray();
-            var compressedString = Utils.ByteArrayToString(compressedBytes);
+            var compressedString = Utils.ByteArrayToHexString(compressedBytes);
 
             // And build the result
             var idProperty = structProperty.Properties.Find(p => p.Name == "ID");

--- a/CompressionHelper.cs
+++ b/CompressionHelper.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using GvasFormat.Serialization;
+using GvasFormat.Serialization.UETypes;
+using ICSharpCode.SharpZipLib.Zip.Compression;
+using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
+
+namespace TSW3LM
+{
+    internal class CompressionHelper
+    {
+        public static Game.Livery? DecompressReskin(UEGenericStructProperty structProperty)
+        {
+            var compressedReskin = structProperty.Properties.FirstOrDefault(p => p is UEArrayProperty && p.Name == "CompressedReskin") as UEArrayProperty;
+            var byteString = compressedReskin?.Items?.FirstOrDefault() as UEByteProperty;
+
+            if (byteString == null)
+                return null;
+
+            var byteArray = Utils.StringToByteArray(byteString.Value);
+            using var memoryStream = new MemoryStream(byteArray);
+            using var binaryReader = new BinaryReader(memoryStream);
+
+            // first 16 bytes are bullshit we can ignore
+            var headerBytes = new byte[16];
+            binaryReader.Read(headerBytes, 0, 16);
+
+            // next 8 bytes store compressed size
+            var compressedSize = binaryReader.ReadInt64();
+            var input = new byte[compressedSize];
+
+            // next 8 bytes store decompressed size
+            var decompressedSize = binaryReader.ReadInt64();
+            var output = new byte[decompressedSize];
+
+            // for whatever reason they repeat the previous 16 bytes, we disregard this
+            binaryReader.ReadInt64();
+            binaryReader.ReadInt64();
+
+            Log.Message("reading compressed file");
+
+            // now begins the actual reading
+
+            // the input will be however long the input file length is
+            for (int i = 0; i < input.Length; i++)
+            {
+                input[i] = binaryReader.ReadByte();
+            }
+
+            // decompress using zlib
+            var inflater = new Inflater();
+
+            // do stuff I saw in the java docs
+            inflater.SetInput(input, 0, input.Length);
+
+            Log.Message("Decompressing using zlib");
+
+            try
+            {
+                var resultLength = inflater.Inflate(output);
+                inflater.Reset();
+
+                Log.Message("Length of decompressed: " + resultLength);
+            }
+            catch (Exception e)
+            {
+                Log.Exception("Failed inflating", e);
+                return null;
+            }
+
+            var decompressedLivery = Utils.ConvertTSW3(output, true);
+            return decompressedLivery;
+        }
+
+        public static UEGenericStructProperty CompressReskin(UEGenericStructProperty structProperty)
+        {
+            // Convert the uncompressed livery into TSW3s compression format
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+            structProperty.SerializeStructProp(writer);
+
+            ms.Position = 0;
+            var bytes = ms.ToArray().ToList();
+
+            // Re-add the bytes necessary for a TSW3 livery
+            bytes.Insert(0, 136);
+            bytes.Insert(1, 123);
+            bytes.Insert(2, 1);
+            bytes.Insert(3, 0);
+            bytes.RemoveAt(bytes.Count - 1);
+
+            // Deflate
+            using var outputByteStream = new MemoryStream();
+            using var deflater = new DeflaterOutputStream(outputByteStream);
+            var byteArray = bytes.ToArray();
+            deflater.Write(byteArray, 0, byteArray.Length);
+            deflater.Finish();
+            outputByteStream.Position = 0;
+            var deflatedBytes = outputByteStream.ToArray();
+
+
+            // Now reassemble the whole thing
+            var header = new byte[] { 193, 131, 42, 158, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0 };
+            var compressedMemoryStream = new MemoryStream();
+            var compressedWriter = new BinaryWriter(compressedMemoryStream);
+
+            compressedWriter.Write(header, 0, header.Length);
+
+            // Write the compressed bytes (twice)
+            compressedWriter.WriteInt64(deflatedBytes.Length);
+            compressedWriter.WriteInt64(byteArray.Length);
+            compressedWriter.WriteInt64(deflatedBytes.Length);
+            compressedWriter.WriteInt64(byteArray.Length);
+
+            // Write the body
+            compressedWriter.Write(deflatedBytes, 0, deflatedBytes.Length);
+
+            // Serialize the thing back to a string
+            compressedMemoryStream.Position = 0;
+            var compressedBytes = compressedMemoryStream.ToArray();
+            var compressedString = Utils.ByteArrayToString(compressedBytes);
+
+            // And build the result
+            var idProperty = structProperty.Properties.Find(p => p.Name == "ID");
+
+            var arrayProperty = new UEArrayProperty
+            {
+                Name = "CompressedReskin",
+                Type = "ArrayProperty",
+                ItemType = "ByteProperty",
+                Count = compressedBytes.Length,
+                ValueLength = compressedBytes.Length + 4,
+                Items = new UEProperty[]
+                {
+                    new UEByteProperty
+                    {
+                        Value = compressedString
+                    }
+                }
+            };
+
+            var compressedProperty = new UEGenericStructProperty
+            {
+                Name = "CompressedReskins",
+                Type = "StructProperty",
+                StructType = "CompressedReskin",
+                Properties = new List<UEProperty>
+                {
+                    idProperty,
+                    arrayProperty,
+                    new UENoneProperty
+                    {
+                        Name = "None"
+                    }
+                }
+            };
+
+            // TODO this calculation is not correct and causes TSW3LM to fail after importing
+            compressedProperty.ValueLength = Utils.DetermineValueLength(compressedProperty, r =>
+            {
+                r.ReadUEString(); //name
+                r.ReadUEString(); //type
+                r.ReadInt64(); //valueLength
+                r.ReadUEString(); //itemType
+                r.ReadByte(); //terminator
+                return r.BaseStream.Length - r.BaseStream.Position;
+            });
+
+            return compressedProperty;
+        }
+    }
+}

--- a/Game.cs
+++ b/Game.cs
@@ -98,15 +98,23 @@ namespace TSW3LM
                     while (Liveries.ContainsKey(i)) i++;
                     var structProperty = (UEGenericStructProperty)LiveryBase;
 
-                    var decompressedLivery = CompressionHelper.DecompressReskin(structProperty);
-
-                    if (decompressedLivery != null)
+                    try
                     {
-                        string name = ((UETextProperty)decompressedLivery.GvasBaseProperty.Properties.First(p => p is UETextProperty && p.Name == "DisplayName")).Value;
-                        string model = ((UEStringProperty)decompressedLivery.GvasBaseProperty.Properties.First(p => p is UEStringProperty && p.Name == "BaseDefinition")).Value.Split(".")[^1];
-                        string newId = GameLiveryInfo.SetInfo(decompressedLivery.ID, name, model);
+                        var decompressedLivery = CompressionHelper.DecompressReskin(structProperty);
 
-                        decompressedLivery.ID = newId;
+                        if (decompressedLivery != null)
+                        {
+                            string name = ((UETextProperty)decompressedLivery.GvasBaseProperty.Properties.First(p => p is UETextProperty && p.Name == "DisplayName")).Value;
+                            string model = ((UEStringProperty)decompressedLivery.GvasBaseProperty.Properties.First(p => p is UEStringProperty && p.Name == "BaseDefinition")).Value.Split(".")[^1];
+                            string newId = GameLiveryInfo.SetInfo(decompressedLivery.ID, name, model);
+
+                            decompressedLivery.ID = newId;
+                        }
+
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Exception("Could not decompress livery " + i, e);
                     }
 
                     Liveries.Add(i, new Livery(structProperty, true));

--- a/Game.cs
+++ b/Game.cs
@@ -152,9 +152,6 @@ namespace TSW3LM
                 });
 
                 GameData.Properties.Add(GvasZipArray);
-
-                // None
-                GameData.Properties.Add(new UENoneProperty());
             }
 
             if (raw.Count > 0)

--- a/Game.cs
+++ b/Game.cs
@@ -185,15 +185,8 @@ namespace TSW3LM
                 return null;
             }
 
-            Log.Message("Successfully decompressed, writing file");
-
-            var filename = Path.Combine(Path.GetTempPath(), $"tsw3reskin{index}.liv");
-            File.WriteAllBytes(filename, output);
-
-            // TODO this doesn't work yet
-            //var decompressedLivery = Utils.ByteArrayToLivery(output, true);
-            //return decompressedLivery;
-            return null;
+            var decompressedLivery = Utils.ConvertTSW3(output, true);
+            return decompressedLivery;
         }
 
         internal static void Save()
@@ -205,37 +198,46 @@ namespace TSW3LM
 
             if (zip.Count > 0)
             {
+                // CompressedReskins
                 GvasZipArray.Count = zip.Count;
                 GvasZipArray.Items = zip.ToArray();
                 GvasZipArray.ValueLength = Utils.DetermineValueLength(GvasZipArray, r =>
                 {
-                    r.ReadUEString();   //name
-                    r.ReadUEString();   //type
-                    r.ReadInt64();      //valueLength
-                    r.ReadUEString();   //itemType
-                    r.ReadByte();       //terminator
+                    r.ReadUEString(); //name
+                    r.ReadUEString(); //type
+                    r.ReadInt64(); //valueLength
+                    r.ReadUEString(); //itemType
+                    r.ReadByte(); //terminator
                     return r.BaseStream.Length - r.BaseStream.Position;
                 });
+
                 GameData.Properties.Add(GvasZipArray);
+
+                // None
+                GameData.Properties.Add(new UENoneProperty());
             }
 
             if (raw.Count > 0)
             {
+                // Reskins
                 GvasRawArray.Count = raw.Count;
                 GvasRawArray.Items = raw.ToArray();
                 GvasRawArray.ValueLength = Utils.DetermineValueLength(GvasRawArray, r =>
                 {
-                    r.ReadUEString();   //name
-                    r.ReadUEString();   //type
-                    r.ReadInt64();      //valueLength
-                    r.ReadUEString();   //itemType
-                    r.ReadByte();       //terminator
+                    r.ReadUEString(); //name
+                    r.ReadUEString(); //type
+                    r.ReadInt64(); //valueLength
+                    r.ReadUEString(); //itemType
+                    r.ReadByte(); //terminator
                     return r.BaseStream.Length - r.BaseStream.Position;
                 });
+
                 GameData.Properties.Add(GvasRawArray);
             }
 
+            // None
             GameData.Properties.Add(new UENoneProperty());
+
 
             File.WriteAllText($"{Config.LibraryPath}\\gvas.json", JsonConvert.SerializeObject(GameData));
 

--- a/Library.cs
+++ b/Library.cs
@@ -23,7 +23,7 @@ namespace TSW3LM
             Log.Message("Loading library...", "L:Load");
             DirectoryInfo Info = new DirectoryInfo(Config.LibraryPath);
             int i = 0;
-            foreach (FileInfo file in Info.GetFiles("*.tsw3", SearchOption.TopDirectoryOnly))
+            foreach (FileInfo file in Info.GetFiles("*.tsw3*", SearchOption.TopDirectoryOnly))
             {
                 try
                 {
@@ -31,7 +31,12 @@ namespace TSW3LM
                     if (livery == null)
                         throw new FormatException("Library livery could not be deserialized");
                     livery.FileName = file.Name;
+                    
+                    if (livery.FileName.EndsWith(".tsw3liv", StringComparison.OrdinalIgnoreCase))
+                        livery.Compressed = false;
+
                     while (Liveries.ContainsKey(i)) i++;
+
                     Liveries.Add(i, livery);
                 }
                 catch (Exception e)
@@ -87,7 +92,7 @@ namespace TSW3LM
 
         internal static void Add(Livery livery)
         {
-            int index = Enumerable.Range(0, Liveries.Count+1).First(i => !Liveries.ContainsKey(i));
+            int index = Enumerable.Range(0, Liveries.Count + 1).First(i => !Liveries.ContainsKey(i));
             Liveries[index] = livery;
         }
 

--- a/Library.cs
+++ b/Library.cs
@@ -32,14 +32,6 @@ namespace TSW3LM
                         throw new FormatException("Library livery could not be deserialized");
                     livery.FileName = file.Name;
 
-                    if (!livery.Compressed)
-                    {
-                        // TSW3 expects compressed liveries only, so if we have an uncompressed .tsw3 file,
-                        // compress it on the fly
-                        livery.GvasBaseProperty = CompressionHelper.CompressReskin(livery.GvasBaseProperty);
-                        livery.Compressed = true;
-                    }
-
                     while (Liveries.ContainsKey(i)) i++;
 
                     Liveries.Add(i, livery);
@@ -86,7 +78,7 @@ namespace TSW3LM
         {
             Log.Message($"Saving library livery {livery.Id}", "L:Save");
 
-            if (livery.Compressed)
+            if (livery.Type == LiveryType.COMPRESSED_TSW3)
             {
                 try
                 {
@@ -95,7 +87,7 @@ namespace TSW3LM
                     if (decompressed != null)
                     {
                         livery.GvasBaseProperty = decompressed.GvasBaseProperty;
-                        livery.Compressed = false;
+                        livery.Type = LiveryType.UNCOMPRESSED_TSW3;
                     }
                 }
                 catch (Exception e)
@@ -130,18 +122,18 @@ namespace TSW3LM
             }
             public string Name { get; set; }
             public string Model { get; set; }
-            public bool Compressed { get; set; }
+            public string Type { get; set; }
 
 
             public UEGenericStructProperty GvasBaseProperty;
 
-            public Livery(string fileName, UEGenericStructProperty property, string name = "<unnamed>", string model = "<unknown>", bool compressed = true)
+            public Livery(string fileName, UEGenericStructProperty property, string type, string name = "<unnamed>", string model = "<unknown>")
             {
                 FileName = fileName;
-                GvasBaseProperty = property;
                 Name = name;
                 Model = model;
-                Compressed = compressed;
+                Type = type;
+                GvasBaseProperty = property;
             }
 
             internal Livery()
@@ -150,7 +142,7 @@ namespace TSW3LM
                 GvasBaseProperty = new UEGenericStructProperty();
                 Name = string.Empty;
                 Model = string.Empty;
-                Compressed = true;
+                Type = LiveryType.COMPRESSED_TSW3;
             }
         }
 

--- a/Library.cs
+++ b/Library.cs
@@ -55,7 +55,7 @@ namespace TSW3LM
                     }
                     File.WriteAllBytes(file.FullName + ".tmp", data);
 
-                    List<UEProperty> properties = new List<UEProperty>();
+                        List<UEProperty> properties = new List<UEProperty>();
 
                     BinaryReader reader = new BinaryReader(File.Open(file.FullName + ".tmp", FileMode.Open, FileAccess.Read, FileShare.Read), Encoding.ASCII, true);
                     while (UEProperty.Read(reader) is UEProperty prop) properties.Add(prop);

--- a/Library.cs
+++ b/Library.cs
@@ -88,17 +88,25 @@ namespace TSW3LM
 
             if (livery.Compressed)
             {
-                var decompressed = CompressionHelper.DecompressReskin(livery.GvasBaseProperty);
-                if (decompressed != null)
+                try
                 {
-                    livery.GvasBaseProperty = decompressed.GvasBaseProperty;
-                    livery.Compressed = false;
+
+                    var decompressed = CompressionHelper.DecompressReskin(livery.GvasBaseProperty);
+                    if (decompressed != null)
+                    {
+                        livery.GvasBaseProperty = decompressed.GvasBaseProperty;
+                        livery.Compressed = false;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.Exception("Could not decompress livery " + livery.Name, e);
                 }
             }
 
             try
             {
-                File.WriteAllText(Config.LibraryPath + "\\" + livery.FileName, JsonConvert.SerializeObject(livery));
+                File.WriteAllText(Config.LibraryPath + "\\" + livery.FileName, JsonConvert.SerializeObject(livery, Formatting.Indented));
             }
             catch (Exception e)
             {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -327,17 +327,15 @@ namespace TSW3LM
             Log.Message($"Exporting livery {gl.ID}", "MW:ExportLivery");
             GameLiveryInfo.Info info = GameLiveryInfo.Get(gl.ID);
 
-            var extension = gl.Compressed ? "tsw3" : "tsw3liv";
-
-            string fileName = Utils.SanitizeFileName($"{info.Name} for {info.Model}.{extension}");
+            string fileName = Utils.SanitizeFileName($"{info.Name} for {info.Model}.tsw3");
             if (info.Name == "<unnamed>" && info.Model == "<unknown>")
             {
                 Log.Message($"Livery Info not set, asking for file name", "MW:ExportLivery", Log.LogLevel.DEBUG);
                 SaveFileDialog Dialog = new SaveFileDialog
                 {
                     InitialDirectory = Config.LibraryPath,
-                    Filter = $"TSW3 Livery File (*.{extension})|*.{extension}",
-                    DefaultExt = $"*.{extension}"
+                    Filter = $"TSW3 Livery File (*.tsw3)|*.tsw3",
+                    DefaultExt = $"*.tsw3"
                 };
                 if (Dialog.ShowDialog() == true)
                     fileName = Utils.SanitizeFileName(Dialog.SafeFileName);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -222,12 +222,19 @@ namespace TSW3LM
             for (int i = 0; i < Config.MaxGameLiveries; i++)
             {
                 if (!Game.Liveries.ContainsKey(i))
-                    lstGameLiveries.Items.Add($"({i+1}) <empty>");
+                    lstGameLiveries.Items.Add($"({i + 1}) <empty>");
                 else
                 {
                     string Id = Game.Liveries[i].ID;
                     GameLiveryInfo.Info Info = GameLiveryInfo.Get(Id);
-                    string Text = Game.Liveries[i].Compressed ? $"({i + 1}) {Info.Name} for {Info.Model}" : $"({i+1}) [RAW] {Info.Name} for {Info.Model}";
+                    string Text = $"({i + 1}) {Info.Name} for {Info.Model}";
+                    switch (Game.Liveries[i].Type)
+                    {
+                        case LiveryType.COMPRESSED_TSW3: break;
+                        case LiveryType.UNCOMPRESSED_TSW3: Text += " [R]"; break;
+                        case LiveryType.CONVERTED_FROM_TSW2: Text += " [2]"; break;
+                        default: Text = "[x] " + Text; break;
+                    }
                     lstGameLiveries.Items.Add(Text);
                     Log.Message($"Added game livery {Text}", "MW:UpdateGameGui", Log.LogLevel.DEBUG);
                 }
@@ -257,7 +264,7 @@ namespace TSW3LM
                 tab_Tsw2.IsSelected = true;
                 Log.Message("Updating TSW2 liveries in GUI...", "MW:UpdateLiveryGui");
                 lstLibraryLiveries.Items.Clear();
-                foreach(FileInfo f in new DirectoryInfo(Config.LibraryPath).GetFiles("*.tsw2liv"))
+                foreach (FileInfo f in new DirectoryInfo(Config.LibraryPath).GetFiles("*.tsw2liv"))
                 {
                     try
                     {
@@ -289,7 +296,7 @@ namespace TSW3LM
                 Library.Save(ll);
             }
 
-            Game.Add(new Game.Livery(ll.GvasBaseProperty, ll.Compressed));
+            Game.Add(new Game.Livery(ll.GvasBaseProperty, ll.Type));
             Log.Message($"Livery successfully imported (ID: {ll.Id})", "MW:ImportLivery", Log.LogLevel.DEBUG);
             ShowStatusText("Livery successfully imported");
         }
@@ -334,8 +341,8 @@ namespace TSW3LM
                 SaveFileDialog Dialog = new SaveFileDialog
                 {
                     InitialDirectory = Config.LibraryPath,
-                    Filter = $"TSW3 Livery File (*.tsw3)|*.tsw3",
-                    DefaultExt = $"*.tsw3"
+                    Filter = "TSW3 Livery File (*.tsw3)|*.tsw3",
+                    DefaultExt = "*.tsw3"
                 };
                 if (Dialog.ShowDialog() == true)
                     fileName = Utils.SanitizeFileName(Dialog.SafeFileName);
@@ -347,7 +354,7 @@ namespace TSW3LM
                 }
             }
 
-            Library.Livery ll = new Library.Livery(fileName, gl.GvasBaseProperty, info.Name, info.Model, gl.Compressed);
+            Library.Livery ll = new Library.Livery(fileName, gl.GvasBaseProperty, info.Name, info.Model, gl.Type);
             Library.Add(ll);
             Library.Save(ll);
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -127,6 +127,13 @@ namespace TSW3LM
 
             InitializeComponent();
 
+            if (Config.LibraryPath != "")
+            {
+                if (File.Exists("LiveryInfo.json"))
+                    File.Move("LiveryInfo.json", $"{Config.LibraryPath}\\zz_LiveryInfo.json");
+                GameLiveryInfo.Init($"{Config.LibraryPath}\\zz_LiveryInfo.json");
+            }
+
             if (Config.GamePath != "")
             {
                 Log.Message("Loading GamePath Data...", "MW::<init>");
@@ -147,12 +154,6 @@ namespace TSW3LM
                 {
                     lblMessage.Content = $"ERROR WHILE LOADING GAME LIVERIES, please ensure you:\n - have created at least one livery in the game\n\nif you need help, consult the wiki at https://github.com/RagingLightning/TSW2-Livery-Manager/wiki/(1)-Getting-Started \n or @RagingLightning on discord or create an issue on github";
                 }
-            }
-            if (Config.LibraryPath != "")
-            {
-                if (File.Exists("LiveryInfo.json"))
-                    File.Move("LiveryInfo.json", $"{Config.LibraryPath}\\zz_LiveryInfo.json");
-                GameLiveryInfo.Init($"{Config.LibraryPath}\\zz_LiveryInfo.json");
             }
 
             UpdateGameGui();
@@ -325,15 +326,18 @@ namespace TSW3LM
         {
             Log.Message($"Exporting livery {gl.ID}", "MW:ExportLivery");
             GameLiveryInfo.Info info = GameLiveryInfo.Get(gl.ID);
-            string fileName = Utils.SanitizeFileName($"{info.Name} for {info.Model}.tsw3");
+
+            var extension = gl.Compressed ? "tsw3" : "tsw3liv";
+
+            string fileName = Utils.SanitizeFileName($"{info.Name} for {info.Model}.{extension}");
             if (info.Name == "<unnamed>" && info.Model == "<unknown>")
             {
                 Log.Message($"Livery Info not set, asking for file name", "MW:ExportLivery", Log.LogLevel.DEBUG);
                 SaveFileDialog Dialog = new SaveFileDialog
                 {
                     InitialDirectory = Config.LibraryPath,
-                    Filter = "TSW3 Livery File (*.tsw3)|*.tsw3",
-                    DefaultExt = "*.tsw3"
+                    Filter = $"TSW3 Livery File (*.{extension})|*.{extension}",
+                    DefaultExt = $"*.{extension}"
                 };
                 if (Dialog.ShowDialog() == true)
                     fileName = Utils.SanitizeFileName(Dialog.SafeFileName);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -21,7 +21,7 @@ namespace TSW3LM
     {
         internal static MainWindow INSTANCE;
 
-        private const string VERSION = "0.2.2";
+        private const string VERSION = "0.3.0";
 
         private Thread InfoCollectorThread = new Thread(GameLiveryInfo.AutoRefresh);
 

--- a/TSW3LM.csproj
+++ b/TSW3LM.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0" />
+    <PackageReference Include="SharpZipLib" Version="1.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Utils.cs
+++ b/Utils.cs
@@ -159,11 +159,11 @@ namespace TSW3LM
         internal static Game.Livery? ConvertTSW3(byte[] tsw2Data, bool catchFormatError)
         {
             var bytes = tsw2Data.ToList();
-            bytes.RemoveRange(0, 2);
-            bytes.Add(0);
+            bytes.RemoveRange(0, 3);
+            bytes.RemoveAt(bytes.Count - 1);
 
             var livery = ConvertTSW2(bytes.ToArray(), catchFormatError);
-            
+
             if (livery != null)
             {
                 string name = ((UETextProperty)livery.GvasBaseProperty.Properties.First(p => p is UETextProperty && p.Name == "DisplayName")).Value;

--- a/Utils.cs
+++ b/Utils.cs
@@ -142,7 +142,7 @@ namespace TSW3LM
             throw new NotImplementedException();
         }
 
-        internal static Game.Livery ConvertTSW2(byte[] tsw2Data, bool catchFormatError)
+        internal static Game.Livery? ConvertTSW2(byte[] tsw2Data, bool catchFormatError)
         {
             byte[] data = new byte[tsw2Data.Length];
             for (int i = 1; i <= tsw2Data.Length; i++)
@@ -153,6 +153,11 @@ namespace TSW3LM
                     data[i - 1] = tsw2Data[i];
             }
 
+            return ByteArrayToLivery(data, catchFormatError);
+        }
+
+        internal static Game.Livery? ByteArrayToLivery(byte[] data, bool catchFormatError)
+        {
             BinaryReader reader = new BinaryReader(new MemoryStream(data));
             UEGenericStructProperty prop = new UEGenericStructProperty();
             prop.StructType = "ReskinSave";
@@ -162,6 +167,7 @@ namespace TSW3LM
             {
                 prop.Properties.Add(p);
             }
+
             try
             {
                 ValidateTsw2Import(prop);

--- a/Utils.cs
+++ b/Utils.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Windows.Forms;
 
 namespace TSW3LM
@@ -163,16 +164,6 @@ namespace TSW3LM
             bytes.RemoveAt(bytes.Count - 1);
 
             var livery = ConvertTSW2(bytes.ToArray(), catchFormatError);
-
-            if (livery != null)
-            {
-                string name = ((UETextProperty)livery.GvasBaseProperty.Properties.First(p => p is UETextProperty && p.Name == "DisplayName")).Value;
-                string model = ((UEStringProperty)livery.GvasBaseProperty.Properties.First(p => p is UEStringProperty && p.Name == "BaseDefinition")).Value.Split(".")[^1];
-                string newId = GameLiveryInfo.SetInfo(livery.ID, name, model);
-
-                livery.ID = newId;
-            }
-
             return livery;
         }
 
@@ -336,6 +327,23 @@ namespace TSW3LM
         }
 
         internal delegate long CVL(BinaryReader r);
+
+        internal static byte[] StringToByteArray(String hex)
+        {
+            int NumberChars = hex.Length;
+            byte[] bytes = new byte[NumberChars / 2];
+            for (int i = 0; i < NumberChars; i += 2)
+                bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+            return bytes;
+        }
+
+        internal static string ByteArrayToString(byte[] ba)
+        {
+            StringBuilder hex = new StringBuilder(ba.Length * 2);
+            foreach (byte b in ba)
+                hex.AppendFormat("{0:x2}", b);
+            return hex.ToString();
+        }
     }
 
     class Log
@@ -437,6 +445,7 @@ namespace TSW3LM
             try
             {
 #pragma warning disable CS8602,CS8600
+                livery.Compressed = jo["Compressed"].Value<bool>();
                 livery.Name = jo["Name"].ToString();
                 livery.Model = jo["Model"].ToString();
                 livery.GvasBaseProperty = (UEGenericStructProperty)ReadUEProperty((JObject)jo["GvasBaseProperty"]);


### PR DESCRIPTION
Decompresses TSW3 liveries to JSON while reading the UGCLiveries_0.sav file. If decompression fails (I've seen this happen with an ICE1 reskin) it leaves the file intact.
- An uncompressed TSW3 livery file gets recompressed during import to game